### PR TITLE
Fix bug where getSecret wasn't working properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ msRestAzure.loginWithAppServiceMSI({resource: 'https://vault.azure.net'}).then( 
     keyVaultClient.setSecret(vaultUri, 'my-secret', 'test-secret-value', {})
         .then( (kvSecretBundle, httpReq, httpResponse) => {
             console.log("Secret id: '" + kvSecretBundle.id + "'.");
-            return keyVaultClient.getSecret(kvSecretBundle.id, {});
+            var secretId = KeyVault.parseSecretIdentifier(kvSecretBundle.id);
+            return keyVaultClient.getSecret(secretId.vault, secretId.name, secretId.version);
         })
         .then( (bundle) => {
             console.log("Successfully retrieved 'test-secret'");


### PR DESCRIPTION
I followed the KeyVault quick start today. It references this repository but the code to get secrets didn't work. I had to update the code like so to get it to work (I believe that this is the latest version of the SDK).

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->